### PR TITLE
엔티티 컬럼 제약 조건 수정 및 테스트 케이스 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,10 @@
 - 사용자 CRUD 로직 수정 및 테스트 코드 추가
 
 - 비밀번호 암호화 로직 추가 ( AOP로 적용)
+
+# 2023 04 16
+- Admin, User 엔티티 컬럼 제약 조건 수정
+
+- ExControllerAdvice에 NullPointerException 추가
+
+- Admin, User 중복 유저 및 조회 불가 오류 테스트 케이스 추가

--- a/src/main/java/com/bbco/practice/web/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/bbco/practice/web/domain/admin/controller/AdminController.java
@@ -52,7 +52,7 @@ public class AdminController {
 
     @DeleteMapping("/admin/{id}")
     public ResponseEntity<AdminResForm> delete(@PathVariable("id") String id) {
-        AdminDto content = service.adminToDto(service.delete(service.findById(id)));
+        AdminDto content = service.adminToDto(service.delete(id));
 
         return new ResponseEntity<>(new AdminResForm(content, "삭제되었습니다.."), HttpStatus.OK);
     }

--- a/src/main/java/com/bbco/practice/web/domain/admin/dto/AdminDto.java
+++ b/src/main/java/com/bbco/practice/web/domain/admin/dto/AdminDto.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/bbco/practice/web/domain/admin/entity/Admin.java
+++ b/src/main/java/com/bbco/practice/web/domain/admin/entity/Admin.java
@@ -18,8 +18,14 @@ public class Admin extends BaseTimeEntity {
 
     @Id @GeneratedValue
     private Long id;
+
+    @Column(unique = true, nullable = false, length = 30)
     private String adminId;
+
+    @Column(nullable = false, length = 30)
     private String password;
+
+    @Column(nullable = false, length = 15)
     private String name;
 
     public Admin(AdminInsertParam param) {
@@ -31,13 +37,5 @@ public class Admin extends BaseTimeEntity {
     public void update(AdminUpdateParam param) {
         if (StringUtils.hasText(param.getPassword())) this.password = param.getPassword();
         if (StringUtils.hasText(param.getName())) this.name = param.getName();
-    }
-
-    public void changePassword(String newPassword) {
-        this.password = newPassword;
-    }
-
-    public void changeName(String newName) {
-        this.name = newName;
     }
 }

--- a/src/main/java/com/bbco/practice/web/domain/admin/service/AdminService.java
+++ b/src/main/java/com/bbco/practice/web/domain/admin/service/AdminService.java
@@ -50,7 +50,7 @@ public class AdminService {
     @Transactional(readOnly = true)
     public Admin findById(String adminId) {
         Admin findAdmin = repository.findByAdminId(adminId)
-                .orElseThrow(() -> new IllegalArgumentException(isNotExist));
+                .orElseThrow(() -> new NullPointerException(isNotExist));
 
 
         log.info("[조회된 관리자 ID] : {}", findAdmin.getAdminId());
@@ -74,11 +74,12 @@ public class AdminService {
         return findAdmin;
     }
 
-    public Admin delete(Admin admin) {
-        repository.delete(admin);
+    public Admin delete(String id) {
+        Admin findAdmin = findById(id);
+        repository.delete(findAdmin);
 
-        log.info("[삭제된 관리자 ID] : {}", admin.getAdminId());
-        return admin;
+        log.info("[삭제된 관리자 ID] : {}", findAdmin.getAdminId());
+        return findAdmin;
     }
 
     public AdminDto adminToDto(Admin admin) {

--- a/src/main/java/com/bbco/practice/web/domain/user/entity/User.java
+++ b/src/main/java/com/bbco/practice/web/domain/user/entity/User.java
@@ -18,15 +18,23 @@ public class User extends BaseTimeEntity {
 
     @Id @GeneratedValue
     private Long id;
+
+    @Column(unique = true, nullable = false, length = 30)
     private String userId;
+
+    @Column(nullable = false, length = 30)
     private String password;
+
+    @Column(nullable = false, length = 15)
     private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "userRank_id")
     private UserRank rank;
 
+    @Column(nullable = false, length = 13)
     private String tel;
+
     @Embedded
     private Address address;
     //private String team; // 추후에 팀 엔티티로 교체

--- a/src/main/java/com/bbco/practice/web/domain/user/service/UserService.java
+++ b/src/main/java/com/bbco/practice/web/domain/user/service/UserService.java
@@ -72,7 +72,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public User findById(String userId) {
         User findUser = userRepository.findByUserId(userId)
-                .orElseThrow(() -> new IllegalArgumentException(isNotExist));
+                .orElseThrow(() -> new NullPointerException(isNotExist));
 
         log.info("[조회된 사용자 ID] : {}", findUser.getUserId());
         return findUser;
@@ -82,7 +82,7 @@ public class UserService {
     @Encrypt
     public User update(String id, UserUpdateParam param) {
         User findUser = userRepository.findByUserId(id)
-                .orElseThrow(() -> new IllegalArgumentException(isNotExist));
+                .orElseThrow(() -> new NullPointerException(isNotExist));
 
         findUser.update(param);
 
@@ -99,7 +99,7 @@ public class UserService {
     @Trace
     public User delete(String id) {
         User findUser = userRepository.findByUserId(id)
-                .orElseThrow(() -> new IllegalArgumentException(isNotExist));
+                .orElseThrow(() -> new NullPointerException(isNotExist));
 
         userRepository.delete(findUser);
 
@@ -126,6 +126,6 @@ public class UserService {
      */
     private UserRank getRank(Long id) {
         return rankRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException(isNotRank));
+                .orElseThrow(() -> new NullPointerException(isNotRank));
     }
 }

--- a/src/main/java/com/bbco/practice/web/excetion/ExControllerAdvice.java
+++ b/src/main/java/com/bbco/practice/web/excetion/ExControllerAdvice.java
@@ -11,6 +11,13 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class ExControllerAdvice {
 
     @ExceptionHandler
+    public ResponseEntity<ErrorResult> nullPoint(NullPointerException e) {
+        log.info("[nullPoint] : [{}]", e.getMessage());
+        ErrorResult errorResult = new ErrorResult("null point", e.getMessage());
+        return new ResponseEntity<>(errorResult, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler
     public ResponseEntity<ErrorResult> badRequest(IllegalArgumentException e) {
         log.info("[badRequest] : [{}]", e.getMessage());
         ErrorResult errorResult = new ErrorResult("bad parameter", e.getMessage());

--- a/src/test/java/com/bbco/practice/web/domain/admin/service/AdminServiceTest.java
+++ b/src/test/java/com/bbco/practice/web/domain/admin/service/AdminServiceTest.java
@@ -16,7 +16,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
@@ -32,6 +32,9 @@ class AdminServiceTest {
     private final String DEFAULT_ADMIN_ID = "admin";
     private final String DEFAULT_ADMIN_PASSWORD = "qwe123";
     private final String DEFAULT_ADMIN_NAME = "관리자";
+
+    private String isExist = "이미 존재하는 관리자 입니다.";
+    private String isNotExist = "존재하는 않는 관리자 입니다.";
 
 
     @BeforeEach
@@ -54,9 +57,21 @@ class AdminServiceTest {
         service.save(newAdminParam);
 
         // then
-        Admin findAdmin = service.findById(newAdminParam.getId());
+        Admin savedAdmin = service.findById(newAdminParam.getId());
 
-        assertThat(findAdmin.getAdminId()).isEqualTo(newAdminParam.getId());
+        assertThat(savedAdmin.getAdminId()).isEqualTo(newAdminParam.getId());
+    }
+
+    @Test
+    @DisplayName("관리자 중복 저장")
+    void saveFail() throws Exception {
+        // given
+        AdminInsertParam newAdminParam = new AdminInsertParam(DEFAULT_ADMIN_ID, DEFAULT_ADMIN_PASSWORD, DEFAULT_ADMIN_NAME);
+        // when && then
+        assertThatIllegalArgumentException().isThrownBy(() -> {
+                service.save(newAdminParam);
+            })
+            .withMessage(isExist);
     }
 
     /**
@@ -70,6 +85,18 @@ class AdminServiceTest {
         Admin findAdmin = service.findById(DEFAULT_ADMIN_ID);
 
         assertThat(findAdmin.getName()).isEqualTo(DEFAULT_ADMIN_NAME);
+    }
+
+    @Test
+    @DisplayName("사용자 조회 실패 (해당 ID 존재하지 않음)")
+    void findOneFail() throws Exception {
+        // given
+        String id = "notExistAdmin";
+        // when && then
+        assertThatNullPointerException().isThrownBy(() -> {
+                service.findById(id);
+            })
+            .withMessage(isNotExist);
     }
 
     /**
@@ -156,8 +183,7 @@ class AdminServiceTest {
         service.save(adminInsertParam);
 
         // when
-        Admin findAdmin = service.findById("bb");
-        service.delete(findAdmin);
+        service.delete("bb");
 
         // then
         Boolean isExist = service.isExist(new AdminSearchCond("bb"));


### PR DESCRIPTION
1. Admin, User 엔티티 컬럼 제약 조건 수정
2. ExControllerAdvice에 NullPointerException 추가
3. Admin, User 중복 유저 및 조회 불가 오류 테스트 케이스 추가